### PR TITLE
Improve log [Conn] Connection closed by peer (user) (#1582)

### DIFF
--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -574,9 +574,10 @@ class NicotineCore:
 
         self.queue.append(slskmessages.PeerConn(None, addr, init))
 
-        log.add_conn("Initialising direct connection of type %(type)s to user %(user)s", {
+        log.add_conn("Attempting direct connection of type %(type)s to user %(user)s %(addr)s", {
             'type': message_type,
-            'user': user
+            'user': user,
+            'addr': addr
         })
 
     def connect_to_peer_indirect(self, conn, error):
@@ -795,7 +796,7 @@ class NicotineCore:
 
                 i.conn = conn
 
-                log.add_conn("Connection established with user %(user)s. List of outgoing messages: %(messages)s", {
+                log.add_conn("Established connection with user %(user)s. List of outgoing messages: %(messages)s", {
                     'user': i.username,
                     'messages': i.msgs
                 })
@@ -876,7 +877,7 @@ class NicotineCore:
                 self.peerconns.remove(i)
 
                 self.show_connection_error_message(i)
-                log.add_conn("Can't connect to user %s neither directly nor indirectly, giving up", i.username)
+                log.add_conn("Cannot connect to user %s neither directly nor indirectly, giving up", i.username)
                 break
 
     def connect_to_peer_timeout(self, msg):
@@ -980,7 +981,7 @@ class NicotineCore:
         if self.ui_callback:
             self.ui_callback.server_disconnect()
 
-    def closed_connection(self, conn, addr, error=None):
+    def closed_connection(self, conn, addr):
 
         if conn == self.active_server_conn:
             self.server_disconnect(addr)
@@ -990,8 +991,8 @@ class NicotineCore:
 
             for i in self.peerconns:
                 if i.conn == conn:
-                    log.add_conn("Connection closed by peer: %(peer)s. Error: %(error)s",
-                                 {'peer': log.contents(i), 'error': error})
+                    log.add_conn("Closed connection of type %(type)s to user %(user)s %(addr)s",
+                                 {'type': i.init.conn_type, 'user': i.username, 'addr': addr})
 
                     if i in self.out_indirect_conn_request_times:
                         del self.out_indirect_conn_request_times[i]
@@ -1018,7 +1019,7 @@ class NicotineCore:
         if msg.connobj.__class__ is slskmessages.ServerConn:
 
             log.add(
-                _("Can't connect to server %(host)s:%(port)s: %(error)s"), {
+                _("Cannot connect to server %(host)s:%(port)s: %(error)s"), {
                     'host': msg.connobj.addr[0],
                     'port': msg.connobj.addr[1],
                     'error': msg.err
@@ -1048,7 +1049,7 @@ class NicotineCore:
                         connect to them. """
 
                         log.add_conn(
-                            "Can't respond to indirect connection request from user %(user)s. Error: %(error)s", {
+                            "Cannot respond to indirect connection request from user %(user)s. Error: %(error)s", {
                                 'user': i.username,
                                 'error': msg.err
                             })


### PR DESCRIPTION
* Fix log [Conn] Connection closed by peer (user)

- closed_connection [Conn] log message syntax was badly broken at %(peer)s resulting in garbled log output spanning multiple lines (purposefully left out Error: %(error)s because it was often contextually incorrect (None) by this point, and more accurate messages will have already been displayed beforehand).

- connect_to_peer_direct [Conn] log message added %(addr)s because it's inexpensive and useful (also changed wording because it's too soon to know if successful init will be possible or not). This extra detail could enable other messages to be omitted for future performance improvements, without reducing usefulness of the [Conn] log.

* Fix log [Conn] removed unused argument and phrases

...at the the start of some messages to make the log easier to search.

Removed an unnecessary line break and de-classed direct connection "Error: Time out" as this is normal client behavior.

Added logging for unknown connection error to "remote host", but I haven't been able to trigger it (unsure as to why the log strings in this definition are translatable).

* Fix log [Conn] Whitespaces

* Remove call to closed_connection from connect_error

This condition doesn't need to be handled here.

Resolve conflict with https://github.com/nicotine-plus/nicotine-plus/commit/36f484d2066c0a4c6886b9436dd6469d8705165f

* Fix log [Conn] Match to resolve Error: on new line

Line in string "Error: " is misplaced, results in broken log output.